### PR TITLE
Change method name to _single_leading_underscore instead of __double_leading_underscore

### DIFF
--- a/logging_journald.py
+++ b/logging_journald.py
@@ -187,7 +187,7 @@ class JournaldLogHandler(logging.Handler):
         "threadName": "thread_name",
     })
 
-    __slots__ = ("__facility", "socket", "__identifier")
+    __slots__ = ("_facility", "socket", "_identifier")
 
     SOCKET_PATH = JournaldTransport.SOCKET_PATH
 

--- a/logging_journald.py
+++ b/logging_journald.py
@@ -207,7 +207,7 @@ class JournaldLogHandler(logging.Handler):
     def _to_usec(ts: float) -> int:
         return int(ts * 1000000)
 
-    def __format_record(self, record: logging.LogRecord) -> List[Tuple[str, Any]]:
+    def _format_record(self, record: logging.LogRecord) -> List[Tuple[str, Any]]:
         message = self.format(record)
         message_traceback = ""
         message_level = self.LEVELS[record.levelno]
@@ -263,7 +263,7 @@ class JournaldLogHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         try:
-            self.transport.send(self.__format_record(record))
+            self.transport.send(self._format_record(record))
         except Exception:
             self._fallback(record)
 

--- a/logging_journald.py
+++ b/logging_journald.py
@@ -199,8 +199,8 @@ class JournaldLogHandler(logging.Handler):
     ):
         super().__init__()
         self.transport = JournaldTransport(socket_path=socket_path)
-        self.__identifier = identifier
-        self.__facility = int(facility)
+        self._identifier = identifier
+        self._facility = int(facility)
         self.use_message_id = use_message_id
 
     @staticmethod
@@ -211,8 +211,8 @@ class JournaldLogHandler(logging.Handler):
         message = self.format(record)
         message_traceback = ""
         message_level = self.LEVELS[record.levelno]
-        message_facility = self.__facility
-        message_identifier = self.__identifier
+        message_facility = self._facility
+        message_identifier = self._identifier
         message_code_string = "{}.{}:{}".format(record.module, record.funcName, record.lineno)
 
         result = [


### PR DESCRIPTION
From https://peps.python.org/pep-0008/#descriptive-naming-styles:
```
__double_leading_underscore: when naming a class attribute, invokes name mangling (inside class FooBar, __boo becomes _FooBar__boo; see below).
```